### PR TITLE
feat: add usdc and dai prices

### DIFF
--- a/src/providers/Coinbase.ts
+++ b/src/providers/Coinbase.ts
@@ -29,6 +29,18 @@ export async function getETHInUSD(): Promise<ProviderSource> {
   }
 }
 
+export async function getDAIInUSD(): Promise<ProviderSource> {
+  try {
+    const response = await fetch("https://api.coinbase.com/v2/prices/DAI-USD/spot")
+    const time = Date.now()
+    const data = (await response.json()) as CBResponse
+    const value = Number(data.data.amount)
+    return { hasError: !value, source: Providers.coinbase, value, time }
+  } catch (error) {
+    return errorResult(error, Providers.coinbase)
+  }
+}
+
 export async function getCELOPrice(): Promise<ProviderSource> {
   try {
     const response = await fetch("https://api.coinbase.com/v2/prices/CGLD-USD/spot")

--- a/src/service/holdings.ts
+++ b/src/service/holdings.ts
@@ -157,8 +157,8 @@ export async function getHoldingsOther() {
     const otherAssets: TokenModel[] = [
       toToken("BTC", btcHeld, rates.btc),
       toToken("ETH", ethHeld, rates.eth),
-      toToken("DAI", daiHeld),
-      toToken("USDC", usdcHeld),
+      toToken("DAI", daiHeld, rates.dai),
+      toToken("USDC", usdcHeld, rates.usdc),
       toToken("cMCO2", cmco2Held, rates.cmco2),
     ]
 
@@ -187,8 +187,8 @@ export default async function getHoldings(): Promise<HoldingsApi> {
   const otherAssets: TokenModel[] = [
     toToken("BTC", btcHeld, rates.btc),
     toToken("ETH", ethHeld, rates.eth),
-    toToken("DAI", daiHeld),
-    toToken("USDC", usdcHeld),
+    toToken("DAI", daiHeld, rates.dai),
+    toToken("USDC", usdcHeld, rates.usdc),
     toToken("cMCO2", cmco2Held, rates.cmco2),
   ]
 

--- a/src/service/rates.ts
+++ b/src/service/rates.ts
@@ -28,6 +28,24 @@ export async function btcPrice() {
   return getOrSave<Duel>("btc-price", fetchBTCPrice, 4 * MINUTE)
 }
 
+async function fetchUSDCPrice() {
+  const price = await duel(getCoinMarketCapPrice("USDC"), getCoinMarketCapPrice("USDC"))
+  return price
+}
+
+export async function usdcPrice() {
+  return getOrSave<Duel>("usdc-price", fetchUSDCPrice, 4 * MINUTE)
+}
+
+async function fetchDAIPrice() {
+  const price = await duel(coinbase.getDAIInUSD(), getCoinMarketCapPrice("DAI"))
+  return price
+}
+
+export async function daiPrice() {
+  return getOrSave<Duel>("dai-price", fetchDAIPrice, 4 * MINUTE)
+}
+
 async function fetchETHPrice() {
   const price = await duel(coinbase.getETHInUSD(), getEthPrice())
   return price
@@ -64,11 +82,13 @@ export async function tokenPriceInUSD(currencySymbol: Tokens) {
 }
 
 export default async function rates() {
-  const [btc, eth, celo, cmco2] = await Promise.all([
+  const [btc, eth, celo, cmco2, usdc, dai] = await Promise.all([
     btcPrice(),
     ethPrice(),
     celoPrice(),
     CMC02Price(),
+    usdcPrice(),
+    daiPrice()
   ])
 
   return {
@@ -76,5 +96,7 @@ export default async function rates() {
     eth,
     celo,
     cmco2,
+    usdc,
+    dai
   }
 }


### PR DESCRIPTION
**Description**
The reserve site so far has been hardcoding USDC and DAI prices to 1. This PR adds the functionality to use actual prices, since USDC and DAI recently depegged. 

Usually, prices have two sources:
- For DAI I chose Coinmarketcap and Coinbase, the only two existing adapters for general asset prices. 
- For USDC, Coinbase halted withdrawals and the price is not up to date. So not adding Coinbase as USDC source for now, but this should be added later. USDC is here only using Coinmarketcap. 

This is the first time I work with this codebase and with a website in general, I couldn't build or test it, only went by logic. I hope Vercel pre-deploys and it looks ok 🙏 