### PR TITLE
add: new Hextrust address

### DIFF
--- a/src/addresses.config.ts
+++ b/src/addresses.config.ts
@@ -12,7 +12,7 @@ const ADDRESSES: ReserveCrypto[] = [
   {
     label: "BTC",
     token: "BTC",
-    addresses: ["38EPdP4SPshc5CiUCzKcLP9v7Vqo5u1HBL", "3KWX93e2zPPQ2eWCsUwPAB6VhAKKPLACou"],
+    addresses: ["38EPdP4SPshc5CiUCzKcLP9v7Vqo5u1HBL", "3Hc1Wje1DeJU5ahXdmD8Pt2yAfoYep331z"],
   },
   {
     label: "ETH",


### PR DESCRIPTION
### Description

The Hextrust address has changed this Pr removes the old one and adds the new one.

### Other changes



### Tested

new Btc Balance includes the Balance of address https://www.blockchain.com/explorer/addresses/btc/3Hc1Wje1DeJU5ahXdmD8Pt2yAfoYep331z

### Related issues



### Backwards compatibility



### Documentation


