### PR TITLE
feat: account for safe holdings

### DIFF
--- a/src/addresses.config.ts
+++ b/src/addresses.config.ts
@@ -1,11 +1,24 @@
 import { Tokens } from "./service/Data"
 
+const wallets = {
+  CUSTODIAN_SAFE: "0xd0697f70E79476195B742d5aFAb14BE50f98CC1E",
+}
+
+const tokensAddresses = {
+  WBTC_ON_ETH: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+  WETH_ON_ETH: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+}
+
 export interface ReserveCrypto {
   token: Tokens
   label: string
   addresses: string[]
   tokenAddress?: string
   decimals?: number
+}
+
+export type ReserveCryptoForDisplay = Omit<ReserveCrypto, "addresses"> & {
+  addresses: { address: string; symbol: Tokens }[]
 }
 
 const ADDRESSES: ReserveCrypto[] = [
@@ -20,6 +33,7 @@ const ADDRESSES: ReserveCrypto[] = [
     addresses: [
       "0xe1955eA2D14e60414eBF5D649699356D8baE98eE",
       "0x8331C987D9Af7b649055fa9ea7731d2edbD58E6B",
+      wallets.CUSTODIAN_SAFE,
     ],
   },
   {
@@ -32,8 +46,20 @@ const ADDRESSES: ReserveCrypto[] = [
     label: "USDC",
     token: "USDC",
     decimals: 6,
-    addresses: ["0x26ac3A7b8a675b741560098fff54F94909bE5E73"],
+    addresses: ["0x26ac3A7b8a675b741560098fff54F94909bE5E73", wallets.CUSTODIAN_SAFE],
     tokenAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+  },
+  {
+    label: "ETH",
+    token: "WETH",
+    addresses: [wallets.CUSTODIAN_SAFE],
+    tokenAddress: tokensAddresses.WETH_ON_ETH,
+  },
+  {
+    label: "BTC",
+    token: "WBTC",
+    addresses: [wallets.CUSTODIAN_SAFE],
+    tokenAddress: tokensAddresses.WBTC_ON_ETH,
   },
 ]
 // WHEN Adding new TOKENS also update the TokenColor enum in PieChart.tsx
@@ -50,6 +76,8 @@ export function generateLink(token: Tokens, address: string) {
       return `https://etherscan.io/address/${address}`
     case "USDC":
     case "DAI":
+    case "WBTC":
+    case "WETH":
       return `https://etherscan.io/address/${address}`
     case "cUSD in Curve Pool":
     case "USDC in Curve Pool":
@@ -57,4 +85,39 @@ export function generateLink(token: Tokens, address: string) {
     case "Partial Reserve":
       return `https://explorer.celo.org/address/${address}`
   }
+}
+
+const tokensToCombine: Tokens[] = ["WETH", "WBTC"] // List of tokens to remove and combine holding addresses with another token with the same labe
+
+export function combineTokenAddressesByLabel(rawTokenList: ReserveCrypto[]) {
+  const combinedList = rawTokenList
+    .map((token) => {
+      // Add symbols to token addresses to facilitate link gereration on a per address basis instead of per token basis
+      return {
+        ...token,
+        addresses: token.addresses.map((address) => ({ address, symbol: token.token })),
+      }
+    })
+    .map((token, i, arr) => {
+      // Combine addresses of tokens that are in the list of tokens to combine with an existing token with the same label
+      if (tokensToCombine.includes(token.token)) {
+        const tokenToCombineWith = arr.find((t) => t.label === token.label)
+        if (tokenToCombineWith) {
+          tokenToCombineWith.addresses = [...tokenToCombineWith.addresses, ...token.addresses]
+        }
+      }
+      // Do nothing if token is not in the list of tokens to combine
+      return token
+    })
+    .filter((token) => !tokensToCombine.includes(token.token)) // Remove tokens which addresses were flagged to be combined
+
+  for (const token of combinedList) {
+    // Remove duplicate addresses introducted by combining tokens which use the same label for different tokens from the same wallet
+    token.addresses = token.addresses.filter(
+      (addressWithSymbol, i, arr) =>
+        arr.findIndex((a) => a.address === addressWithSymbol.address) === i
+    )
+  }
+
+  return combinedList
 }

--- a/src/components/ReserveAddresses.tsx
+++ b/src/components/ReserveAddresses.tsx
@@ -1,12 +1,12 @@
 import { css } from "@emotion/react"
 import * as React from "react"
-import { ReserveCrypto, generateLink } from "src/addresses.config"
+import { ReserveCryptoForDisplay, generateLink } from "src/addresses.config"
 import Button from "src/components/Button"
 import CopyIcon from "src/components/CopyIcon"
 import { Tokens } from "src/service/Data"
 
 interface Props {
-  addresses: ReserveCrypto[]
+  addresses: ReserveCryptoForDisplay[]
 }
 
 export default function ReserveAddresses(props: Props) {
@@ -35,23 +35,27 @@ function useCopy(hex: string) {
   return { onPress, justCopied }
 }
 
-const TokenDisplay = React.memo(function _TokenDisplay({ label, addresses, token }: ReserveCrypto) {
+const TokenDisplay = React.memo(function _TokenDisplay({
+  label,
+  addresses,
+  token,
+}: ReserveCryptoForDisplay) {
   return (
     <div css={rootStyle}>
       <h5 css={labelStyle}>{label}</h5>
-      {addresses.map((address) => (
-        <AddressDisplay key={address} token={token} hex={address} />
+      {addresses.map(({ address, symbol }) => (
+        <AddressDisplay key={address} token={token} hex={address} symbol={symbol} />
       ))}
     </div>
   )
 })
 
-function AddressDisplay({ token, hex }: { token: Tokens; hex: string }) {
+function AddressDisplay({ hex, symbol }: { token: Tokens; hex: string; symbol: Tokens }) {
   const { onPress, justCopied } = useCopy(hex)
 
   return (
     <div css={entryCss}>
-      <a css={addressStyle} href={generateLink(token, hex)} target="_blank" rel="noopener">
+      <a css={addressStyle} href={generateLink(symbol, hex)} target="_blank" rel="noopener">
         {hex}
       </a>
       <span css={iconStyle} onClick={onPress}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,7 +11,7 @@ import Section from "src/components/Section"
 import { flexCol } from "src/components/styles"
 import PieChart from "src/components/PieChart"
 import useTargets from "src/hooks/useTargets"
-import { ReserveCrypto } from "src/addresses.config"
+import { ReserveCryptoForDisplay, combineTokenAddressesByLabel } from "src/addresses.config"
 
 interface ContentShape {
   title: string
@@ -24,7 +24,7 @@ interface Props {
   ATTESTATIONS: FrontMatterResult<ContentShape>
   RFP: FrontMatterResult<ContentShape>
   year: string
-  reserveCryptos: ReserveCrypto[]
+  reserveCryptos: ReserveCryptoForDisplay[]
 }
 
 export default function Home(props: Props) {
@@ -112,6 +112,8 @@ export async function getStaticProps() {
       ])
     const addresses = await fetchAddresses()
 
+    const tokensCombinedByLabels = combineTokenAddressesByLabel(addresses)
+
     const INTRO = matter<ContentShape>(intro)
     const INITIAL_TARGET = matter<ContentShape>(initialTarget)
     const ABOUT = matter<ContentShape>(about)
@@ -119,7 +121,7 @@ export async function getStaticProps() {
     const RFP = matter<ContentShape>(rfp)
     return {
       props: {
-        reserveCryptos: addresses,
+        reserveCryptos: tokensCombinedByLabels,
         INTRO,
         INITIAL_TARGET,
         ABOUT,

--- a/src/service/Data.ts
+++ b/src/service/Data.ts
@@ -11,6 +11,10 @@ export type Tokens =
   | "cUSD in Curve Pool"
   | "USDC in Curve Pool"
   | "Partial Reserve"
+  | "CELO"
+  | "WBTC"
+  | "WETH"
+
 export interface Address {
   address: string
   label: string

--- a/src/service/Data.ts
+++ b/src/service/Data.ts
@@ -11,7 +11,6 @@ export type Tokens =
   | "cUSD in Curve Pool"
   | "USDC in Curve Pool"
   | "Partial Reserve"
-  | "CELO"
   | "WBTC"
   | "WETH"
 

--- a/src/service/holdings.ts
+++ b/src/service/holdings.ts
@@ -187,13 +187,15 @@ function toCeloShape(
 
 export async function getHoldingsOther() {
   const rates = await getRates()
-  const [btcHeld, ethHeld, daiHeld, usdcHeld, cmco2Held] = allOkOrThrow(
+  const [btcHeld, ethHeld, daiHeld, usdcHeld, cmco2Held, wethHeld, wbtcHeld] = allOkOrThrow(
     await Promise.all([
       btcBalance(),
       ethBalance(),
       erc20OnEthereumBalance("DAI"),
       erc20OnEthereumBalance("USDC"),
       cMC02Balance(),
+      erc20OnEthereumBalance("WETH"),
+      erc20OnEthereumBalance("WBTC"),
     ])
   )
 
@@ -201,6 +203,8 @@ export async function getHoldingsOther() {
   ethHeld.value += await uniV3HoldingsForToken(RESERVE_MULTISIG_CELO, ETH_WORMHOLE_ADDRESS)
   btcHeld.value += await uniV3HoldingsForToken(RESERVE_MULTISIG_CELO, BTC_AXELAR_ADDRESS)
   btcHeld.value += await uniV3HoldingsForToken(RESERVE_MULTISIG_CELO, BTC_WORMHOLE_ADDRESS)
+  btcHeld.value += wbtcHeld.value
+  ethHeld.value += wethHeld.value
 
   usdcHeld.value += valueOrThrow(await getCurvePoolUSDC())
   usdcHeld.value += valueOrThrow(await multisigUSDC())
@@ -219,23 +223,37 @@ export async function getHoldingsOther() {
 
 export default async function getHoldings(): Promise<HoldingsApi> {
   const rates = await getRates()
-  const [btcHeld, ethHeld, daiHeld, usdcHeld, celoCustodied, frozen, unfrozen, cmco2Held] =
-    allOkOrThrow(
-      await Promise.all([
-        btcBalance(),
-        ethBalance(),
-        erc20OnEthereumBalance("DAI"),
-        erc20OnEthereumBalance("USDC"),
-        celoCustodiedBalance(),
-        celoFrozenBalance(),
-        celoUnfrozenBalance(),
-        cMC02Balance(),
-      ])
-    )
+  const [
+    btcHeld,
+    ethHeld,
+    daiHeld,
+    usdcHeld,
+    celoCustodied,
+    frozen,
+    unfrozen,
+    cmco2Held,
+    wethHeld,
+    wbtcHeld,
+  ] = allOkOrThrow(
+    await Promise.all([
+      btcBalance(),
+      ethBalance(),
+      erc20OnEthereumBalance("DAI"),
+      erc20OnEthereumBalance("USDC"),
+      celoCustodiedBalance(),
+      celoFrozenBalance(),
+      celoUnfrozenBalance(),
+      cMC02Balance(),
+      erc20OnEthereumBalance("WETH"),
+      erc20OnEthereumBalance("WBTC"),
+    ])
+  )
 
   usdcHeld.value += valueOrThrow(await getCurvePoolUSDC())
   usdcHeld.value += valueOrThrow(await multisigUSDC())
   usdcHeld.value += valueOrThrow(await partialReserveUSDC())
+  btcHeld.value += wbtcHeld.value
+  ethHeld.value += wethHeld.value
 
   const otherAssets: TokenModel[] = [
     toToken("BTC", btcHeld, rates.btc),


### PR DESCRIPTION
### Description

This PR expands the reserve collateral count to include ETH, WETH, USDC, and WBTC balances from our Reserve Safe Multisig on Ethereum. I've also made changes to combine tokens on Ethereum under one heading, e.g., list WETH under the ETH label. 

This also required changing how links to the explorers for each address in the token lists are generated. Addresses are now generated on a per holding address basis instead of a per-token basis. 

### Other changes

N/A

### Tested

Tested locally -

USDC & ETH balances now account for current holdings in (0xd0697f70E79476195B742d5aFAb14BE50f98CC1E) 

Used 0xBF72Da2Bd84c5170618Fbe5914B0ECA9638d5eb5 to test WBTC is accounted for
Used 0x2F0b23f53734252Bda2277357e97e1517d6B042A to test WETH is accounted for

Checked that all holding addresses link to their respective explorers 

### Related issues

- Fixes #39 

### Backwards compatibility

N/A

### Documentation

N/A
