### PR TITLE
fix: add new dai holding address on ethereum

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "typescript": "^4.3.5"
   },
   "engines": {
-    "node": "14"
+    "node": "18"
   },
   "lint-staged": {
     "*.{ts,tsx,md,yaml}": "prettier --write"

--- a/src/addresses.config.ts
+++ b/src/addresses.config.ts
@@ -39,7 +39,10 @@ const ADDRESSES: ReserveCrypto[] = [
   {
     label: "DAI",
     token: "DAI",
-    addresses: ["0x16B34Ce9A6a6F7FC2DD25Ba59bf7308E7B38E186"],
+    addresses: [
+      "0x16B34Ce9A6a6F7FC2DD25Ba59bf7308E7B38E186",
+      "0xd0697f70E79476195B742d5aFAb14BE50f98CC1E",
+    ],
     tokenAddress: "0x6b175474e89094c44da98b954eedeac495271d0f",
   },
   {

--- a/src/addresses.config.ts
+++ b/src/addresses.config.ts
@@ -39,10 +39,7 @@ const ADDRESSES: ReserveCrypto[] = [
   {
     label: "DAI",
     token: "DAI",
-    addresses: [
-      "0x16B34Ce9A6a6F7FC2DD25Ba59bf7308E7B38E186",
-      "0xd0697f70E79476195B742d5aFAb14BE50f98CC1E",
-    ],
+    addresses: ["0x16B34Ce9A6a6F7FC2DD25Ba59bf7308E7B38E186", wallets.CUSTODIAN_SAFE],
     tokenAddress: "0x6b175474e89094c44da98b954eedeac495271d0f",
   },
   {


### PR DESCRIPTION
### Description

Add new DAI holding address on ethereum

### Other changes

Updated node engine to 18:

<img width="1230" alt="image" src="https://github.com/mento-protocol/reserve-site/assets/304771/a87b2a06-5414-4143-9fcf-088f1e866810">


### Tested

Ran the dev server

### Related issues

- Fixes #43 

### Backwards compatibility

Yes

### Documentation

NA