### PR TITLE
fix: skip position calc for empty pools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ firebase-debug.log
 # misc
 .DS_Store
 *.pem
+.vercel


### PR DESCRIPTION
### Description

This change will skip the calculation we are doing for pool balances where the liquidity of the pool is zero. This was causing the BTC balance to display zero as this logic was returning ∞.

### Tested

- Verified change works as expected on local instance and preview

