### PR TITLE
fix: unbatch RPC calls and fix UI warning

### DIFF
--- a/src/components/ReserveAddresses.tsx
+++ b/src/components/ReserveAddresses.tsx
@@ -1,14 +1,8 @@
 import { css } from "@emotion/react"
 import * as React from "react"
-import {
-  ReserveCryptoForDisplay,
-  generateLink,
-  ReserveAssetByLabel,
-  ReserveCrypto,
-} from "src/addresses.config"
+import { generateLink, ReserveAssetByLabel, ReserveCrypto } from "src/addresses.config"
 import Button from "src/components/Button"
 import CopyIcon from "src/components/CopyIcon"
-import { Tokens } from "src/service/Data"
 
 interface Props {
   reserveAssets: ReserveAssetByLabel
@@ -18,7 +12,7 @@ export default function ReserveAddresses(props: Props) {
   return (
     <>
       {Object.entries(props.reserveAssets).map(([label, assets]) => {
-        return <AssetDisplay label={label} assets={assets} />
+        return <AssetDisplay key={label} label={label} assets={assets} />
       })}
       <Button href="https://docs.celo.org/command-line-interface/reserve">
         Query Reserve Holdings
@@ -50,13 +44,17 @@ const AssetDisplay = React.memo(function _TokenDisplay({
   return (
     <div css={rootStyle}>
       <h5 css={labelStyle}>{label}</h5>
-      {assets.map((asset) => (
-        <>
-          {asset.addresses.map((address) => (
-            <AddressDisplay key={address} asset={asset} hex={address} />
-          ))}
-        </>
-      ))}
+      {assets
+        .map((asset) =>
+          asset.addresses.map((address) => (
+            <AddressDisplay
+              key={`${asset.label}-${address}-${asset.token}`}
+              asset={asset}
+              hex={address}
+            />
+          ))
+        )
+        .flat()}
     </div>
   )
 })

--- a/src/providers/Celo.ts
+++ b/src/providers/Celo.ts
@@ -45,16 +45,6 @@ const uniV3BalanceCalculator = UniV3PoolBalanceCalculator.Instance
 const provider = new JsonRpcProvider(process.env.CELO_NODE_RPC_URL)
 const eXOFContract = new Contract(EXOF_ADDRESS, ERC20_ABI, provider)
 
-export async function getCeloPrice(): Promise<ProviderResult> {
-  try {
-    const exchange = await kit.contracts.getExchange()
-    const rate = await exchange.quoteGoldSell(WEI_PER)
-    return providerOk(formatNumber(rate), Providers.celoNode)
-  } catch (error) {
-    return providerError(error, Providers.celoNode)
-  }
-}
-
 export async function getFrozenBalance(): Promise<ProviderResult> {
   try {
     const [reserve, nativeToken] = await Promise.all([

--- a/src/providers/EthereumRPC.ts
+++ b/src/providers/EthereumRPC.ts
@@ -5,12 +5,12 @@ import { providerError, providerOk, ProviderResult } from "src/utils/ProviderRes
 import { formatNumber } from "./utils"
 import { Providers } from "./Providers"
 
-let _provider: ethers.providers.JsonRpcBatchProvider | null = null
+let _provider: ethers.providers.JsonRpcProvider | null = null
 const RPC_URL = process.env.ETHEREUM_RPC_URL
 
-function getProvider(): ethers.providers.JsonRpcBatchProvider {
+function getProvider(): ethers.providers.JsonRpcProvider {
   if (_provider === null) {
-    _provider = new ethers.providers.JsonRpcBatchProvider(RPC_URL)
+    _provider = new ethers.providers.JsonRpcProvider(RPC_URL)
   }
   return _provider
 }

--- a/src/service/rates.ts
+++ b/src/service/rates.ts
@@ -1,7 +1,6 @@
 import * as coinbase from "src/providers/Coinbase"
 import { ISO427SYMBOLS } from "src/interfaces/ISO427SYMBOLS"
 import currencyInUSD from "src/providers/ExchangeRateAPI"
-import { getCeloPrice } from "src/providers/Celo"
 import { getEthPrice } from "src/providers/Etherscan"
 import { getOrSave, Cachable } from "src/service/cache"
 import { HOUR, MINUTE } from "src/utils/TIME"

--- a/src/service/rates.ts
+++ b/src/service/rates.ts
@@ -87,8 +87,7 @@ export async function fiatPrices() {
 }
 
 async function fetchCELOPrice() {
-  const price = await duel(getCeloPrice(), coinbase.getCELOPrice())
-  return price
+  return coinbase.getCELOPrice()
 }
 
 export async function celoPrice() {


### PR DESCRIPTION
### Description

We had an outage on the Reserve site last night, which seems to be caused by Infura timing out on our batched RPC calls.
It's intermittent and probably due to some internal scaling/infrastructure changes happening there.

I've removed the batching. But to improve performance and loading time and to get things in line, I suggest migrating all ethers and contractkit usage to `viem` so we can (easily) make use of `multicall` to not just batch at the RPC level but actually batch reads into a single RPC call, reducing the load.

### Other changes

- Removed price loading via the exchange - no longer working
- Fixed a React key issue

### Tested

Yes

### Related issues

N/A

### Backwards compatibility

N/A

### Documentation

N/A