### PR TITLE
feat: track reserve usdt balance

### DIFF
--- a/src/addresses.config.ts
+++ b/src/addresses.config.ts
@@ -1,5 +1,5 @@
 import { Tokens } from "./service/Data"
-import { RESERVE_MULTISIG_CELO } from "./contract-addresses"
+import { RESERVE_ADDRESS, RESERVE_MULTISIG_CELO } from "./contract-addresses"
 
 const wallets = {
   RESERVE_MULTISIG_ETH: "0xd0697f70E79476195B742d5aFAb14BE50f98CC1E",
@@ -151,7 +151,7 @@ const ADDRESSES: ReserveCrypto[] = [
     label: "USDT",
     token: "USDT",
     decimals: 6,
-    addresses: [wallets.RESERVE_MULTISIG_CELO],
+    addresses: [wallets.RESERVE_MULTISIG_CELO, RESERVE_ADDRESS],
     tokenAddress: tokensAddresses.USDT_ON_CELO,
     network: Network.CELO,
   },

--- a/src/addresses.config.ts
+++ b/src/addresses.config.ts
@@ -13,7 +13,7 @@ const tokensAddresses = {
   STEUR_ON_CELO: "0x004626a008b1acdc4c74ab51644093b155e59a23",
   SAVINGS_DAI: "0x83f20f44975d03b1b09e64809b757c47f942beea",
   LIDO_STAKED_ETH: "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
-  USDC_ON_CELO: "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+  USDT_ON_CELO: "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
 }
 
 export enum AssetType {
@@ -152,7 +152,7 @@ const ADDRESSES: ReserveCrypto[] = [
     token: "USDT",
     decimals: 6,
     addresses: [wallets.RESERVE_MULTISIG_CELO],
-    tokenAddress: tokensAddresses.USDC_ON_CELO,
+    tokenAddress: tokensAddresses.USDT_ON_CELO,
     network: Network.CELO,
   },
 ]

--- a/src/addresses.config.ts
+++ b/src/addresses.config.ts
@@ -13,6 +13,7 @@ const tokensAddresses = {
   STEUR_ON_CELO: "0x004626a008b1acdc4c74ab51644093b155e59a23",
   SAVINGS_DAI: "0x83f20f44975d03b1b09e64809b757c47f942beea",
   LIDO_STAKED_ETH: "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+  USDC_ON_CELO: "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
 }
 
 export enum AssetType {
@@ -145,6 +146,15 @@ const ADDRESSES: ReserveCrypto[] = [
     tokenAddress: tokensAddresses.LIDO_STAKED_ETH,
     network: Network.ETH,
   },
+  {
+    assetType: AssetType.ERC20,
+    label: "USDT",
+    token: "USDT",
+    decimals: 6,
+    addresses: [wallets.RESERVE_MULTISIG_CELO],
+    tokenAddress: tokensAddresses.USDC_ON_CELO,
+    network: Network.CELO,
+  },
 ]
 // WHEN Adding new TOKENS also update the TokenColor enum in PieChart.tsx
 
@@ -172,6 +182,8 @@ export function generateLink(token: ReserveCrypto, address: string) {
         return `https://etherscan.io/address/${address}`
       case "stEUR":
         return `https://explorer.celo.org/mainnet/address/${address}`
+      case "USDT":
+        return `https://explorer.celo.org/address/${address}/coin_balances`
     }
   } else if (token.assetType === AssetType.ERC20InCurvePool) {
     // TODO: This mimics the existing implementation but we can think of a better

--- a/src/components/PieChart.tsx
+++ b/src/components/PieChart.tsx
@@ -22,7 +22,7 @@ enum TokenColor {
   cMCO2 = colors.green,
   sDAI = colors.blue,
   stETH = colors.green,
-  USDT = colors.lightBlue,
+  USDT = colors.darkolivegreen,
 }
 
 interface Props {

--- a/src/components/PieChart.tsx
+++ b/src/components/PieChart.tsx
@@ -22,6 +22,7 @@ enum TokenColor {
   cMCO2 = colors.green,
   sDAI = colors.blue,
   stETH = colors.green,
+  USDT = colors.lightBlue,
 }
 
 interface Props {

--- a/src/components/colors.ts
+++ b/src/components/colors.ts
@@ -9,6 +9,7 @@ enum colors {
   green = "#77D2A7",
   violet = "#BF97FF",
   purpleGray = "#716b94",
+  darkolivegreen = "#556B2F",
 }
 
 export default colors

--- a/src/service/Data.ts
+++ b/src/service/Data.ts
@@ -16,6 +16,7 @@ export type Tokens =
   | "stEUR"
   | "sDAI"
   | "stETH"
+  | "USDT"
 
 export interface Address {
   address: string

--- a/src/service/holdings.ts
+++ b/src/service/holdings.ts
@@ -218,6 +218,7 @@ export async function getHoldingsOther() {
     stEurHeld,
     sDaiHeld,
     stEthHeld,
+    usdtHeld,
   ] = allOkOrThrow(
     await Promise.all([
       btcBalance(),
@@ -230,6 +231,7 @@ export async function getHoldingsOther() {
       erc20Balance("stEUR", Network.CELO),
       erc20Balance("sDAI", Network.ETH),
       erc20Balance("stETH", Network.ETH),
+      erc20Balance("USDT", Network.CELO),
     ])
   )
 
@@ -256,6 +258,7 @@ export async function getHoldingsOther() {
     toToken("stEUR", stEurHeld, rates.euroc),
     toToken("sDAI", sDaiHeld, rates.sDai),
     toToken("stETH", stEthHeld, rates.stEth),
+    toToken("USDT", usdtHeld, rates.usdt),
   ]
 
   return { otherAssets }

--- a/src/service/rates.ts
+++ b/src/service/rates.ts
@@ -34,6 +34,11 @@ async function fetchUSDCPrice() {
   return price
 }
 
+async function fetchUSDTPrice() {
+  const price = await duel(getCoinMarketCapPrice("USDT"), getCoinMarketCapPrice("USDT"))
+  return price
+}
+
 async function fetchEUROCPrice() {
   const price = await duel(getCoinMarketCapPrice("EURC"), getCoinMarketCapPrice("EURC"))
   return price
@@ -70,6 +75,10 @@ async function fetchStETHPrice() {
 
 export async function stEthPrice() {
   return getOrSave<DuelResult>("stEth-price", fetchStETHPrice, 4 * MINUTE)
+}
+
+export async function usdtPrice() {
+  return getOrSave<DuelResult>("usdt-price", fetchUSDTPrice, 4 * MINUTE)
 }
 
 async function fetchETHPrice() {

--- a/src/service/rates.ts
+++ b/src/service/rates.ts
@@ -115,7 +115,7 @@ export async function tokenPriceInUSD(currencySymbol: Tokens) {
 }
 
 export default async function rates() {
-  const [btc, eth, celo, cmco2, usdc, euroc, dai, sDai, stEth] = allOkOrThrow(
+  const [btc, eth, celo, cmco2, usdc, euroc, dai, sDai, stEth, usdt] = allOkOrThrow(
     await Promise.all([
       btcPrice(),
       ethPrice(),
@@ -126,6 +126,7 @@ export default async function rates() {
       daiPrice(),
       sDaiPrice(),
       stEthPrice(),
+      usdtPrice(),
     ])
   )
 
@@ -139,5 +140,6 @@ export default async function rates() {
     dai,
     sDai,
     stEth,
+    usdt,
   }
 }


### PR DESCRIPTION
### Description

Updates the site to track USDT held by the reserve.

### Other changes

- None

### Tested

Used an [address](https://celoscan.io/address/0x6c4BF064e178f21EdBA398B42fB7db3E0112c925) that holds USDT to verify the changes:

![image](https://github.com/mento-protocol/reserve-site/assets/6872903/4b8a4d41-190c-470f-ace8-da4670b6a680)

