### PR TITLE
feat: remove cmco2 price fetch

### DIFF
--- a/src/service/rates.ts
+++ b/src/service/rates.ts
@@ -115,12 +115,11 @@ export async function tokenPriceInUSD(currencySymbol: Tokens) {
 }
 
 export default async function rates() {
-  const [btc, eth, celo, cmco2, usdc, euroc, dai, sDai, stEth, usdt] = allOkOrThrow(
+  const [btc, eth, celo, usdc, euroc, dai, sDai, stEth, usdt] = allOkOrThrow(
     await Promise.all([
       btcPrice(),
       ethPrice(),
       celoPrice(),
-      CMC02Price(),
       usdcPrice(),
       eurocPrice(),
       daiPrice(),
@@ -134,7 +133,6 @@ export default async function rates() {
     btc,
     eth,
     celo,
-    cmco2,
     usdc,
     euroc,
     dai,


### PR DESCRIPTION
### Description

Subgraph for the Ubeswap is not available anymore which causes price fetching for the CMCO2 to fail.
This was probably happening for a long time but we had CMC API as the backup.
But our subscription for the CMC is expired and that caused price fetching to fail altogether.

We removed the calls for the CMCO2 price, the info about the CMCO2 was removed from the display already.
Also, we updated the API key for the CMC temporarily to a free key. We are going to use and rotate free keys until the subscription is renewed

### Other changes

No

### Tested

Preview:

<img width="1086" alt="image" src="https://github.com/mento-protocol/reserve-site/assets/17413894/f2300d99-90df-4040-a70a-b66615c6168c">


### Related issues

- Discord


