### PR TITLE
fix: remove double accounting of univ3 usdt holdings

### DIFF
--- a/src/service/holdings.ts
+++ b/src/service/holdings.ts
@@ -305,11 +305,6 @@ export async function getHoldingsOther() {
   btcHeld.value += wbtcHeld.value;
   ethHeld.value += wethHeld.value;
 
-  usdtHeld.value += await uniV3HoldingsForToken(
-    RESERVE_MULTISIG_CELO,
-    USDT_CELO_NATIVE_ADDRESS,
-  );
-
   usdcHeld.value += valueOrThrow(await getCurvePoolUSDC());
   usdcHeld.value += valueOrThrow(await multisigUSDC());
   usdcHeld.value += valueOrThrow(await reserveUSDC());


### PR DESCRIPTION
### Description

We are adding the univ3 usdt holdings twice to the total usdt holdings. This pr removes one of those additions. 

### Other changes


### Tested



### Related issues



### Backwards compatibility



### Documentation


